### PR TITLE
Using passed NonceLength instead of calculating it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+.idea/

--- a/ccm.go
+++ b/ccm.go
@@ -31,6 +31,7 @@ type CCMType struct {
 	blk cipher.Block //
 	M   uint64       // # of octets(bytes) in authentication field	(field size 3) == (M-2)/2
 	L   uint64       // # of octets(bytes) in length field			(field size 3) == L-1
+	N   uint64       // nonce size
 	err error
 }
 
@@ -112,7 +113,7 @@ func newCCMType(blk cipher.Block, TagSize int, NonceSize int) (c *CCMType, err e
 	}
 
 	// All Good - return it.
-	c = &CCMType{blk: blk, M: uint64(TagSize), L: uint64(l)}
+	c = &CCMType{blk: blk, M: uint64(TagSize), L: uint64(l), N: uint64(NonceSize)}
 	return
 }
 
@@ -170,20 +171,6 @@ func MaxNonceLength(pdatalen int) int {
 		}
 	}
 	return 0
-}
-
-// Working with SJCL assumes that you have a 32 bit arcitecture and this limits the outputs from this.
-func CalculateNonceLengthFromMessageLength(lenOfPlaintext int) int {
-	var L int
-	// ivl := 4 * 4 // ivl  - length of 'iv' in bytes -				// From SJCL
-
-	// compute the length of the length
-	// 63     for (L=2; L<4 && lenOfPlaintext >>> 8*L; L++) {}		// From SJCL
-	for L = 2; L < 4 && (lenOfPlaintext>>uint32(8*L)) > 0; L++ {
-	}
-	// 64     if (L < 15 - ivl) { L = 15-ivl; } 					// From SJCL
-	// 65     iv = w.clamp(iv,8*(15-L));
-	return 15 - L
 }
 
 /*
@@ -355,12 +342,11 @@ func (ccmt *CCMType) Seal(dst, nonce, plaintext, adata []byte) (rv []byte) {
 	ccmt.err = nil // No errors yet
 
 	// if nonce is too long then truncate it.
-	NonceLength := CalculateNonceLengthFromMessageLength(int(ccmt.L))
-	if len(nonce) > NonceLength {
-		nonce = nonce[0:NonceLength]
+	if len(nonce) > int(ccmt.N) {
+		nonce = nonce[0:ccmt.N]
 	}
 
-	if ll := 15 - NonceLength; ll != int(ccmt.L) {
+	if ll := 15 - int(ccmt.N); ll != int(ccmt.L) {
 		// godebug.Printf(db1, "****************** l=%d ccmt.L=%d\n", ll, ccmt.L)
 		ccmt.err = ErrInvalidNonceLength
 		return
@@ -389,9 +375,8 @@ func (ccmt *CCMType) Seal(dst, nonce, plaintext, adata []byte) (rv []byte) {
 func (ccmt *CCMType) Open(dst, nonce, ct, adata []byte) ([]byte, error) {
 	var InitializationVector [CcmBlockSize]byte
 
-	NonceLength := CalculateNonceLengthFromMessageLength(len(ct) - int(ccmt.M))
-	if len(nonce) > NonceLength {
-		nonce = nonce[0:NonceLength] // Truncate if too long
+	if len(nonce) > int(ccmt.N) {
+		nonce = nonce[0:int(ccmt.N)] // Truncate if too long
 	}
 
 	if len(ct) > ccmt.MaxLength()+ccmt.Overhead() {
@@ -424,9 +409,9 @@ func (ccmt *CCMType) Open(dst, nonce, ct, adata []byte) ([]byte, error) {
 }
 
 func maximumLengthForMessage(L uint64, TagSize uint64) int {
-	//godebug.Printf(db2, "input L=%v TagSize=%v, %s\n", L, TagSize, godebug.LF())
+	//godebug.Printf("input L=%v TagSize=%v, %s\n", L, TagSize, godebug.LF())
 	if !is64BitArch {
-		//godebug.Printf(db2, "**** At: %s\n", godebug.LF())
+		//godebug.Printf("**** At: %s\n", godebug.LF())
 		return int(math.MaxInt32 - TagSize)
 	}
 	max := (uint64(1) << (8 * L)) - 1 // 32 bit maximum length - works with SJCL
@@ -436,11 +421,8 @@ func maximumLengthForMessage(L uint64, TagSize uint64) int {
 	}
 	return int(max)
 	// }
-	//godebug.Printf(db2, "At: %s\n", godebug.LF())
+	//godebug.Printf("At: %s\n", godebug.LF())
 	// return int(math.MaxInt32)
 }
-
-const db1 = false
-const db2 = false
 
 /* vim: set noai ts=4 sw=4: */

--- a/ccm.go
+++ b/ccm.go
@@ -355,7 +355,7 @@ func (ccmt *CCMType) Seal(dst, nonce, plaintext, adata []byte) (rv []byte) {
 	ccmt.err = nil // No errors yet
 
 	// if nonce is too long then truncate it.
-	NonceLength := CalculateNonceLengthFromMessageLength(len(plaintext))
+	NonceLength := CalculateNonceLengthFromMessageLength(int(ccmt.L))
 	if len(nonce) > NonceLength {
 		nonce = nonce[0:NonceLength]
 	}

--- a/ccm_test.go
+++ b/ccm_test.go
@@ -114,7 +114,7 @@ func TestAESCCM(t *testing.T) {
 	}
 
 	for i, v := range testDataRfc3610 {
-		godebug.Printf(db_TestAESCCM, "Test: %d ---------------------------------------------------------------------------\n", i)
+		godebug.Printf("Test: %d ---------------------------------------------------------------------------\n", i)
 
 		key := decodeAndCheck(v.key, i)
 		nonce := decodeAndCheck(v.nonce, i)
@@ -310,7 +310,7 @@ func Test_maximumLengthForMessage(t *testing.T) {
 		// func maximumLengthForMessage(L uint64, TagSize uint64) int {
 		jj := maximumLengthForMessage(vv.L, vv.TagSize)
 
-		godebug.Printf(db_TestAESCCM_1, "L %d TagSize %d Out %d\n", vv.L, vv.TagSize, jj)
+		godebug.Printf("L %d TagSize %d Out %d\n", vv.L, vv.TagSize, jj)
 
 		if true {
 			if kk := maximumLengthForMessage(vv.L, vv.TagSize); kk != vv.out {
@@ -320,8 +320,5 @@ func Test_maximumLengthForMessage(t *testing.T) {
 	}
 
 }
-
-const db_TestAESCCM = false
-const db_TestAESCCM_1 = false
 
 /* vim: set noai ts=4 sw=4: */

--- a/ccm_test.go
+++ b/ccm_test.go
@@ -235,29 +235,6 @@ func Test_01(t *testing.T) {
 
 }
 
-func Test_NonceLength(t *testing.T) {
-	var testData = []struct {
-		in    int
-		nonce int
-	}{
-		{nonce: 13, in: 20},
-		{nonce: 13, in: 200},
-		{nonce: 13, in: 2000},
-		{nonce: 13, in: 20000},
-		{nonce: 12, in: 200000},
-		{nonce: 12, in: 2000000},
-		{nonce: 11, in: 20000000},
-		{nonce: 11, in: 200000000},
-	}
-
-	for ii, vv := range testData {
-		if kk := CalculateNonceLengthFromMessageLength(vv.in); kk != vv.nonce {
-			t.Errorf("Invalid NonceLength Test %d, Expected %d, got %d\n", ii, vv.nonce, kk)
-		}
-	}
-
-}
-
 func BenchmarkAESCCMSeal(b *testing.B) {
 	var key [aes.BlockSize]byte
 	var nonce [13]byte

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/pschlump/AesCCM
+
+go 1.18
+
+require (
+	github.com/mattn/go-colorable v0.1.1 // indirect
+	github.com/mattn/go-isatty v0.0.5 // indirect
+	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
+	github.com/pschlump/MiscLib v1.0.1 // indirect
+	github.com/pschlump/godebug v1.0.4 // indirect
+	github.com/pschlump/json v0.0.0-20180316172947-0d2e6a308e08 // indirect
+	golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=
+github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
+github.com/mattn/go-isatty v0.0.5 h1:tHXDdz1cpzGaovsTB+TVB8q90WEokoVmfMqoVcrLUgw=
+github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
+github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/pschlump/MiscLib v1.0.1 h1:37ndOKe2rBG33Zop/gmsk995fNKcAITDTi6qhGtMIHI=
+github.com/pschlump/MiscLib v1.0.1/go.mod h1:33BegrXglROGxpDvBSciKSCc1oEKj6oRgJWD5ZEX+ZI=
+github.com/pschlump/godebug v1.0.4 h1:X37zf4qXgsQhT4mceDet768mAimjxFDpsis7zEl8A80=
+github.com/pschlump/godebug v1.0.4/go.mod h1:0g877qgD7yUdH5NUqp6hg/QTvR0LLIBGpuk7FeUlmWE=
+github.com/pschlump/json v0.0.0-20180316172947-0d2e6a308e08 h1:vlHZH1VS4Wt4C8Jk1y8C6UqnpT54RuKWkV8iRc9Bwp4=
+github.com/pschlump/json v0.0.0-20180316172947-0d2e6a308e08/go.mod h1:MyeKNxcsYS/AaCqIp6DgPdaE/4NVH49OJVCnQsRoevI=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpblAHI6s6TDM39bFZumv8=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
The current logic calculates the required nonce length, although it was passed as parameter. Most implementation, e.g. Java, are accepting a nonce which is shorter and are adjusting the L parameter for the message. Usually the nonce has a fixed size and the message length field has to adjust to this by indicating that larger messages would supported, although the passed message is much shorter. Putting to know the correct nonce length depending on the message is a problem for developers. This fix is storing the passed nonce and is only cutting the nonce if the passed nonce is too large. 
This behavior does not violate the RFC.